### PR TITLE
Scene Management Implementation

### DIFF
--- a/CSC8508/Scene/Scene.h
+++ b/CSC8508/Scene/Scene.h
@@ -1,0 +1,29 @@
+﻿//
+// Contributors: Alfie
+//
+
+#ifndef SCENE_H
+#define SCENE_H
+
+class Scene {
+public:
+    virtual ~Scene() = default;
+
+    /**
+     * Called when the SceneManager has just changed the current Scene to this one.
+     */
+    virtual void OnLoad() { }
+
+    /**
+     * Called every tick when this Scene is the SceneManager's current scene.
+     * @param dt Delta time: The change in time from the last tick in seconds
+     */
+    virtual void Update(float dt) { }
+
+    /**
+     * Called when the SceneManager has just changed the current scene away from this one.
+     */
+    virtual void OnUnload() { }
+};
+
+#endif //SCENE_H

--- a/CSC8508/Scene/Scene.h
+++ b/CSC8508/Scene/Scene.h
@@ -5,6 +5,9 @@
 #ifndef SCENE_H
 #define SCENE_H
 
+/**
+ * Base class for all game scenes. Scenes should be saved on the heap, then registered using SceneManager::Set().
+ */
 class Scene {
 public:
     virtual ~Scene() = default;

--- a/CSC8508/Scene/SceneManager.cpp
+++ b/CSC8508/Scene/SceneManager.cpp
@@ -1,0 +1,7 @@
+﻿//
+// Contributors: Alfie
+//
+
+#include "SceneManager.h"
+
+Scene* SceneManager::current = nullptr;

--- a/CSC8508/Scene/SceneManager.h
+++ b/CSC8508/Scene/SceneManager.h
@@ -7,7 +7,8 @@
 #include "Scene.h"
 
 /**
- * SceneManager is a static class that holds pointers to the game's different scenes and dictates the current
+ * SceneManager is a static class that holds pointers to the game's different scenes and dictates the current. The game
+ * loop should grab the current scene from here and call its Update().
  */
 class SceneManager final {
 public:
@@ -68,6 +69,5 @@ inline void SceneManager::SetCurrent(Scene* scene) {
     if (old) old->OnUnload();
     if (current) current->OnLoad();
 }
-
 
 #endif //SCENEMANAGER_H

--- a/CSC8508/Scene/SceneManager.h
+++ b/CSC8508/Scene/SceneManager.h
@@ -30,7 +30,7 @@ public:
      * @param scene Scene instance
      */
     template <typename S>
-    static void Set(S* const scene) { sceneInstance<S> = scene; }
+    static void SetInstance(S* const scene) { sceneInstance<S> = scene; }
 
     /**
      * Gets the static singleton instance for a target Scene type.
@@ -38,7 +38,7 @@ public:
      * @return Scene instance or NULLPTR if not set
      */
     template <typename S>
-    static S* Get() { return sceneInstance<S>; }
+    static S* GetInstance() { return sceneInstance<S>; }
 
     /**
      * Sets the current Scene pointer to the static singleton instance of a target scene type.

--- a/CSC8508/Scene/SceneManager.h
+++ b/CSC8508/Scene/SceneManager.h
@@ -1,0 +1,73 @@
+﻿//
+// Contributors: Alfie
+//
+
+#ifndef SCENEMANAGER_H
+#define SCENEMANAGER_H
+#include "Scene.h"
+
+/**
+ * SceneManager is a static class that holds pointers to the game's different scenes and dictates the current
+ */
+class SceneManager final {
+public:
+    /**
+     * Changes the current Scene pointer to the target Scene and calls OnLoad() and OnUnload() in the new and old
+     * current Scenes respectively.
+     * @param scene Target Scene
+     */
+    static inline void SetCurrent(Scene* scene);
+
+    /**
+     * @return Current Scene pointer or NULLPTR if not yet set.
+     */
+    static Scene* GetCurrent() { return current; }
+
+    /**
+     * Sets the static singleton instance for a target Scene type.
+     * @tparam S Scene type (child class)
+     * @param scene Scene instance
+     */
+    template <typename S>
+    static void Set(S* const scene) { sceneInstance<S> = scene; }
+
+    /**
+     * Gets the static singleton instance for a target Scene type.
+     * @tparam S Scene type (child class)
+     * @return Scene instance or NULLPTR if not set
+     */
+    template <typename S>
+    static S* Get() { return sceneInstance<S>; }
+
+    /**
+     * Sets the current Scene pointer to the static singleton instance of a target scene type.
+     * @tparam S
+     */
+    template <typename S>
+    static void SetCurrentToInstance() { SetCurrent(sceneInstance<S>); }
+
+private:
+    static Scene* current;
+
+    /**
+     * Static singleton Scene instance: When making a new Scene type, a pointer to the scene should be stored here.
+     * @tparam S
+     */
+    template <typename S>
+    static S* sceneInstance;
+};
+
+
+template <typename S>
+S* SceneManager::sceneInstance = nullptr;
+
+
+inline void SceneManager::SetCurrent(Scene* scene) {
+    Scene* old = current;
+    current = scene;
+    if (old) old->OnUnload();
+    if (current) current->OnLoad();
+}
+
+
+#endif //SCENEMANAGER_H


### PR DESCRIPTION
Static scene management and pointer system. Firstly, it lets you store singletons statically making it very easy to access Scene objects (e.g.` SceneManager::Get<MenuScene>()` returns a pointer to the menu screen). Then it also handles a pointer to the current scene so the game loop knows where it should call an update function. It also calls `OnLoad()` and `OnUnload()` Scene functions as needed.

There's some example implementation code [on Discord](https://discordapp.com/channels/1326512512430116874/1333408737435582566/1334180774026674258) if you fancy testing.