### PR TITLE
Add feature channel groups & modify load/play sounds

### DIFF
--- a/AudioEngine/AudioEngine.cpp
+++ b/AudioEngine/AudioEngine.cpp
@@ -10,6 +10,18 @@ AudioEngine::AudioEngine() : audioSystem(nullptr) {
     FMOD::System_Create(&audioSystem);
 	// Set FMOD to use a right-handed coordinate system
 	audioSystem->init(512, FMOD_INIT_3D_RIGHTHANDED, nullptr);
+
+	// Create channel groups
+	masterGroup = CreateChannelGroups(ChannelGroupType::MASTER, "Master");
+
+	musicGroup = CreateChannelGroups(ChannelGroupType::MUSIC, "Music");
+	sfxGroup = CreateChannelGroups(ChannelGroupType::SFX, "SFX");
+	voiceGroup = CreateChannelGroups(ChannelGroupType::VOICE, "Voice");
+
+	masterGroup->addGroup(musicGroup);
+	masterGroup->addGroup(sfxGroup);
+	masterGroup->addGroup(voiceGroup);
+
 }
 
 
@@ -36,4 +48,16 @@ void AudioEngine::Shutdown() {
         audioSystem->close();
         audioSystem->release();
     }
+}
+
+FMOD::ChannelGroup* AudioEngine::CreateChannelGroups(ChannelGroupType type, const char* name) {
+	FMOD::ChannelGroup* group;
+	if (audioSystem->createChannelGroup(name, &group) == FMOD_OK) {
+		channelGroups[type] = group;
+		return group;
+	}
+	else {
+		// Error creating channel group
+		return nullptr;
+	}
 }

--- a/AudioEngine/AudioEngine.h
+++ b/AudioEngine/AudioEngine.h
@@ -8,6 +8,20 @@
 
 #include <fmod.hpp>
 
+/**
+* Type of Channel Group
+* SFX
+* MUSIC
+* VOICE
+* MASTER
+*/
+enum class ChannelGroupType {
+	SFX,
+	MUSIC,
+	VOICE,
+	MASTER
+};
+
 
 /**
 * Audio Engine is a singleton class that manages the FMOD Audio System.
@@ -38,20 +52,45 @@ public:
 	* Reference needed for each AudioObject
 	* @return FMOD System instance
 	*/
-	FMOD::System* GetSystem() { return audioSystem; }
+	FMOD::System* GetSystem() {
+		return audioSystem;
+	}
 
 	/**
 	* Handle Destruction of Audio Engine
     */
     void Shutdown();
 
-	void setMasterVolume(float volume) {
-		masterGroup->setVolume(volume);
+	/**
+	* Get pointer to a channel group
+	* @return FMOD Channel Group
+	* @param type of channel group
+	*/
+	FMOD::ChannelGroup* GetChannelGroup(ChannelGroupType type) {
+		return channelGroups[type];
 	}
 
-	FMOD::ChannelGroup* getMasterGroup() {
-		return masterGroup;
+
+	/**
+	* Set volume of a channel group
+	* @param type of channel group
+	* @param volume to set
+	*/
+	void SetChannelVolume(ChannelGroupType type, float volume) {
+		GetChannelGroup(type)->setVolume(volume);
 	}
+
+	/**
+	* Get current volume of a channel group
+	* @return float volume of channel group
+	* @param type of channel group
+	*/
+	float GetChannelVolume(ChannelGroupType type) {
+		float volume;
+		GetChannelGroup(type)->getVolume(&volume);
+		return volume;
+	}
+
 
 private:
     AudioEngine();
@@ -59,8 +98,17 @@ private:
 
     FMOD::System* audioSystem;
 
+
+	std::map<ChannelGroupType, FMOD::ChannelGroup*> channelGroups;
+
 	FMOD::ChannelGroup* masterGroup;
 
+	FMOD::ChannelGroup* sfxGroup;
+	FMOD::ChannelGroup* musicGroup;
+	FMOD::ChannelGroup* voiceGroup;
+
+	FMOD::ChannelGroup* CreateChannelGroups(ChannelGroupType type, const char* name);
+	
 };
 
 #endif


### PR DESCRIPTION
Channel groups allow for different audio groups (SFX, Music, Chat) to have different base volumes. A master group controls the global volume of all of these sounds. 

Methods have been added to get & set the volume of channels. 

Loading and playing a file has also been modified. Audio sources now have a map of all sounds it has access to. These sounds can then be played by accessing this map and will allow for cycling through/randomly playing sounds.