### PR TITLE
Add and implement basic CollisionEvent and update concepts

### DIFF
--- a/CSC8508/Scene/Scene.h
+++ b/CSC8508/Scene/Scene.h
@@ -29,8 +29,8 @@ public:
     virtual void OnUnload() { }
 };
 
-// SceneType must be a child class of Scene
+// SceneType must be a child class of Scene, but not Scene
 template <typename T>
-concept SceneType = std::is_base_of_v<Scene, T>;
+concept SceneType = std::is_base_of_v<Scene, T> && !std::is_same_v<Scene, T>;
 
 #endif //SCENE_H

--- a/CSC8508CoreClasses/CMakeLists.txt
+++ b/CSC8508CoreClasses/CMakeLists.txt
@@ -48,6 +48,7 @@ set(Collision_Detection
     "CapsuleVolume.cpp"
     "CollisionDetection.h"
     "CollisionDetection.cpp"
+	"CollisionEvent.h"
     "OBBVolume.h"
     "QuadTree.h"
     "QuadTree.cpp"

--- a/CSC8508CoreClasses/CollisionEvent.h
+++ b/CSC8508CoreClasses/CollisionEvent.h
@@ -1,0 +1,20 @@
+﻿//
+// Contributors: Alfie
+//
+
+#ifndef COLLISIONEVENT_H
+#define COLLISIONEVENT_H
+#include "CollisionDetection.h"
+#include "Event.h"
+
+using namespace NCL;
+
+struct CollisionEvent : Event {
+    GameObject const & object1, & object2;
+    CollisionDetection::CollisionInfo const& collisionInfo;
+
+    CollisionEvent(GameObject& object1, GameObject& object2, CollisionDetection::CollisionInfo& collisionInfo)
+        : object1(object1), object2(object2), collisionInfo(collisionInfo) { }
+};
+
+#endif //COLLISIONEVENT_H

--- a/CSC8508CoreClasses/PhysicsSystem.cpp
+++ b/CSC8508CoreClasses/PhysicsSystem.cpp
@@ -13,6 +13,8 @@
 #include "Debug.h"
 #include "Window.h"
 #include <functional>
+
+#include "CollisionEvent.h"
 using namespace NCL;
 using namespace CSC8508;
 
@@ -161,8 +163,10 @@ void PhysicsSystem::BasicCollisionDetection() {
 				continue;
 			}
 			CollisionDetection::CollisionInfo info;
-			if (CollisionDetection::ObjectIntersection(*i, *j, info)) 
+			if (CollisionDetection::ObjectIntersection(*i, *j, info))
 			{
+				auto e = CollisionEvent((*i)->GetGameObject(), (*j)->GetGameObject(), info);
+				EventManager::Call(&e);
 				ImpulseResolveCollision(*info.a, *info.b, info.point);
 				info.framesLeft = numCollisionFrames;
 				allCollisions.insert(info);
@@ -280,6 +284,8 @@ void PhysicsSystem::NarrowPhase() {
 	for (std::set<CollisionDetection::CollisionInfo>::iterator i = broadphaseCollisions.begin(); i != broadphaseCollisions.end(); ++i) {
 		CollisionDetection::CollisionInfo info = *i;
 		if (CollisionDetection::ObjectIntersection(info.a, info.b, info)) {
+			auto e = CollisionEvent(info.a->GetGameObject(), info.b->GetGameObject(), info);
+			EventManager::Call(&e);
 			info.framesLeft = numCollisionFrames;
 			ImpulseResolveCollision(*info.a, *info.b, info.point);
 			allCollisions.insert(info); // insert into our main set

--- a/Event/Event.h
+++ b/Event/Event.h
@@ -44,8 +44,8 @@ protected:
 };
 
 
-// EventType must be a child class of Event
+// EventType must be a child class of Event, but not Event or CancellableEvent
 template <typename T>
-concept EventType = std::is_base_of_v<Event, T>;
+concept EventType = std::is_base_of_v<Event, T> && !(std::is_same_v<Event, T> || std::is_same_v<CancellableEvent, T>);
 
 #endif //EVENT_H


### PR DESCRIPTION
Really small PR, just did two things:

Firstly, collisions now fire off a "CollisionEvent", which includes references to the game objects that collided. No listeners added yet but will likely need them when we start adding in AI behaviour.

Secondly, I implemented the second part of the concept change I wanted to in a previous PR. Now you can't accidentally make a listener for type "Event" or "CancellableEvent", the compiler won't let you (if you did this, the event manager wouldn't work properly. This change just points out bugs before they arise). Similar thing with the SceneType concept, just enforcing intended usage.

Pls check it compiles and maybe make a test listener for the collision event? If you do, make sure to not have every collision spam you, maybe just (if object,hasTag(player)) or something like that.