### PR TITLE
Inventory sync impl

### DIFF
--- a/AudioEngine/NetworkedListenerComponent.h
+++ b/AudioEngine/NetworkedListenerComponent.h
@@ -35,8 +35,8 @@ namespace NCL::CSC8508 {
 	class NetworkedListenerComponent : public AudioListenerComponent, public INetworkComponent {
 
 	public:
-		NetworkedListenerComponent(GameObject& gameObject, PerspectiveCamera& camera, int objId, int ownId, int componId, bool clientOwned) :
-			AudioListenerComponent(gameObject, camera), INetworkComponent(objId, ownId, componId, clientOwned) {}
+		NetworkedListenerComponent(GameObject& gameObject, PerspectiveCamera& camera, int objId, int ownId, int componId, int pFabId, bool clientOwned) :
+			AudioListenerComponent(gameObject, camera), INetworkComponent(objId, ownId, componId, pFabId, clientOwned) {}
 
 		~NetworkedListenerComponent() = default;
 

--- a/CSC8508/GameInstantiations.cpp
+++ b/CSC8508/GameInstantiations.cpp
@@ -24,20 +24,22 @@ int GetUniqueId(int objectId, int& componentCount) {
 }
 
 
-void TutorialGame::Loaditem(const Vector3& position, NetworkSpawnData* spawnData) {
+GameObject* TutorialGame::Loaditem(const Vector3& position, NetworkSpawnData* spawnData) {
 	std::string gameObjectPath = GetAssetPath("object_data.pfab");
 	GameObject* myObjectToLoad = new GameObject();
 	myObjectToLoad->Load(gameObjectPath);
-	myObjectToLoad->GetTransform().SetPosition(myObjectToLoad->GetTransform().GetPosition() + position);
+	myObjectToLoad->GetTransform().SetPosition(position);
 	myObjectToLoad->AddComponent<ItemComponent>(10);
 	myObjectToLoad->GetRenderObject()->SetColour(Vector4(0, 1, 0, 1));
 	if (spawnData)
 	{	
+		int pFabId = spawnData->pfab;
 		int componentIdCount = 0;
 		TransformNetworkComponent* networkTransform = myObjectToLoad->AddComponent<TransformNetworkComponent>(
-			spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), spawnData->clientOwned);
+			spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), pFabId, spawnData->clientOwned);
 	}
 	world->AddGameObject(myObjectToLoad);
+	return myObjectToLoad;
 }
 
 GameObject* TutorialGame::AddPlayerToWorld(const Vector3& position, NetworkSpawnData* spawnData) {
@@ -80,18 +82,19 @@ GameObject* TutorialGame::AddPlayerToWorld(const Vector3& position, NetworkSpawn
 
 	if (spawnData)
 	{
+		int pFabId = spawnData->pfab;
 		int unqiueId = GetUniqueId(spawnData->objId, componentIdCount);
 		InputNetworkComponent* input = player->AddComponent<InputNetworkComponent>(
-			controller, spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), spawnData->clientOwned);
+			controller, spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), pFabId, spawnData->clientOwned);
 
 		InventoryNetworkManagerComponent* inventoryManager = player->AddComponent<InventoryNetworkManagerComponent>(2, carryOffset, dropOffset,
-			spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), spawnData->clientOwned);
+			spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), pFabId, spawnData->clientOwned);
 
 		TransformNetworkComponent* networkTransform = player->AddComponent<TransformNetworkComponent>(
-			spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), spawnData->clientOwned);
+			spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), pFabId, spawnData->clientOwned);
 		
 		NetworkedListenerComponent* listenerComp = player->AddComponent<NetworkedListenerComponent>(
-			world->GetMainCamera(), spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), spawnData->clientOwned);
+			world->GetMainCamera(), spawnData->objId, spawnData->ownId, GetUniqueId(spawnData->objId, componentIdCount), pFabId, spawnData->clientOwned);
 		listenerComp->RecordMic();
 
 		AudioSourceComponent* sourceComp = player->AddComponent<AudioSourceComponent>();

--- a/CSC8508/GameInstantiations.cpp
+++ b/CSC8508/GameInstantiations.cpp
@@ -65,9 +65,9 @@ GameObject* TutorialGame::AddPlayerToWorld(const Vector3& position, NetworkSpawn
 	StaminaComponent* stamina = player->AddComponent<StaminaComponent>(100,100, 3);
 	PlayerComponent* pc = player->AddComponent<PlayerComponent>();
 
-	pc->SetBindingDash(KeyCodes::SHIFT, stamina);
-	pc->SetBindingJump(KeyCodes::SPACE, stamina);
-	pc->SetBindingInteract(KeyCodes::E);
+	pc->SetBindingDash(controller->GetButtonHashId("Dash"), stamina);
+	pc->SetBindingJump(controller->GetButtonHashId("Jump"), stamina);
+	pc->SetBindingInteract(controller->GetButtonHashId("Interact"));
 
 	SightComponent* sight = player->AddComponent<SightComponent>();
 	PhysicsComponent* phys = player->AddComponent<PhysicsComponent>();

--- a/CSC8508/InventoryManagerComponent.h
+++ b/CSC8508/InventoryManagerComponent.h
@@ -86,8 +86,8 @@ namespace NCL {
             void RemoveItemEntry(int inventoryIndex) {
                 storedItems.erase(storedItems.begin() + inventoryIndex);
             }
-        protected:
 
+        protected:
             int maxItemStorage;
             int scrollIndex = 0;
             float itemCarryOffset;
@@ -106,7 +106,6 @@ namespace NCL {
                 Transform& objectTransform = storedItems[inventoryIndex]->GetGameObject().GetTransform();
                 objectTransform.SetPosition(transform.GetPosition() + GetDirection() * itemDropOffset);
             }
-
 
             ItemComponent* PopItemFromInventory(int inventoryIndex) {
                 if (inventoryIndex < 0 || inventoryIndex >= storedItems.size()) return nullptr;

--- a/CSC8508/InventoryManagerComponent.h
+++ b/CSC8508/InventoryManagerComponent.h
@@ -73,7 +73,19 @@ namespace NCL {
 
             void Load(std::string assetPath, size_t allocationStart) override;
             size_t Save(std::string assetPath, size_t* allocationStart) override;
-                
+            
+            void RemoveItemEntry(ItemComponent* item) {
+                for (int i = 0; i < storedItems.size(); i++) {
+                    if (storedItems[i] == item) {
+                        RemoveItemEntry(i);
+                        return;
+                    }
+                }
+            }
+
+            void RemoveItemEntry(int inventoryIndex) {
+                storedItems.erase(storedItems.begin() + inventoryIndex);
+            }
         protected:
 
             int maxItemStorage;
@@ -95,14 +107,14 @@ namespace NCL {
                 objectTransform.SetPosition(transform.GetPosition() + GetDirection() * itemDropOffset);
             }
 
+
             ItemComponent* PopItemFromInventory(int inventoryIndex) {
                 if (inventoryIndex < 0 || inventoryIndex >= storedItems.size()) return nullptr;
                 ItemComponent* item = storedItems[inventoryIndex];
                 item->SetEnabledComponentStates(true);
                 item->GetGameObject().SetEnabled(true);
                 ReturnItemToWorld(inventoryIndex);
-
-                storedItems.erase(storedItems.begin() + inventoryIndex);
+                RemoveItemEntry(inventoryIndex);
                 return item;
             }
         };

--- a/CSC8508/InventoryNetworkManagerComponent.cpp
+++ b/CSC8508/InventoryNetworkManagerComponent.cpp
@@ -4,7 +4,6 @@
 using namespace NCL;
 using namespace CSC8508;
 
-
 void InventoryNetworkManagerComponent::TrySetStoredItems(InventoryNetworkState* lastInvFullState, int i) {
 	ItemComponent* itemDelta = nullptr;
 	ComponentManager::OperateOnBufferContents<TransformNetworkComponent>(
@@ -16,7 +15,6 @@ void InventoryNetworkManagerComponent::TrySetStoredItems(InventoryNetworkState* 
 			}
 		}
 	);
-
 	if (itemDelta != nullptr) {
 		ComponentManager::OperateOnBufferContents<InventoryManagerComponent>(
 			[&itemDelta](InventoryManagerComponent* o) { o->RemoveItemEntry(itemDelta);});
@@ -59,8 +57,6 @@ bool InventoryNetworkManagerComponent::ReadFullPacket(IFullNetworkPacket& ifp) {
 	}
 	return true;
 }
-
-
 
 vector<GamePacket*> InventoryNetworkManagerComponent::WritePacket() {
 	vector<GamePacket*> packets;

--- a/CSC8508/InventoryNetworkManagerComponent.h
+++ b/CSC8508/InventoryNetworkManagerComponent.h
@@ -24,10 +24,10 @@ namespace NCL::CSC8508 {
 	class InventoryNetworkManagerComponent : public InventoryManagerComponent, public INetworkDeltaComponent {
 
 	public:
-		InventoryNetworkManagerComponent(GameObject& gameObject, int maxStorage, float carryOffset, float dropOffset, int objId, int ownId, int componId, bool clientOwned)
+		InventoryNetworkManagerComponent(GameObject& gameObject, int maxStorage, float carryOffset, float dropOffset, int objId, int ownId, int componId, int pfabID, bool clientOwned)
 			:
 			InventoryManagerComponent(gameObject, maxStorage, carryOffset, dropOffset),
-			INetworkDeltaComponent(objId, ownId, componId, clientOwned, new InventoryNetworkState()) {
+			INetworkDeltaComponent(objId, ownId, componId, pfabID, clientOwned, new InventoryNetworkState()) {
 		}
 
 		virtual std::unordered_set<std::type_index>& GetDerivedTypes() const override {

--- a/CSC8508/NetworkedGame.cpp
+++ b/CSC8508/NetworkedGame.cpp
@@ -29,7 +29,7 @@ struct SpawnPacket : public GamePacket {
 
 	short ownerId;
 	short objectId;
-	// add a prefab reference in the future
+	short pfabId;
 
 	SpawnPacket() {
 		type = Spawn_Object;
@@ -39,7 +39,10 @@ struct SpawnPacket : public GamePacket {
 
 void NetworkedGame::StartClientCallBack() { StartAsClient(10, 70, 33, 111); } //IP config
 void NetworkedGame::StartServerCallBack() { StartAsServer(); }
-void NetworkedGame::StartOfflineCallBack() { TutorialGame::AddPlayerToWorld(Vector3(90, 22, -50)); }
+void NetworkedGame::StartOfflineCallBack() { 
+	TutorialGame::AddPlayerToWorld(Vector3(90, 22, -50)); 
+	TutorialGame::Loaditem(Vector3(93, 22, -53));
+}
 
 
 void NetworkedGame::OnEvent(HostLobbyConnectEvent* e) { StartAsServer(); }
@@ -78,7 +81,8 @@ void NetworkedGame::StartAsServer()
 
 	thisServer->RegisterPacketHandler(Delta_State, this);
 	thisServer->RegisterPacketHandler(Full_State, this);
-	SpawnPlayerServer(thisServer->GetPeerId(), Prefab::Player);
+	SpawnObjectServer(thisServer->GetPeerId(), Prefab::Player);
+	SpawnObjectServer(thisServer->GetPeerId(), Prefab::Item);
 }
 
 void NetworkedGame::StartAsClient(char a, char b, char c, char d) 
@@ -100,7 +104,7 @@ void NetworkedGame::OnEvent(ClientConnectedEvent* e)
 {
 	int id = e->GetClientId();
 	SendSpawnPacketsOnClientConnect(id);	
-	SpawnPlayerServer(id, Prefab::Player);
+	SpawnObjectServer(id, Prefab::Player);
 }
 
 void NetworkedGame::OnEvent(NetworkEvent* e)
@@ -185,34 +189,49 @@ void NetworkedGame::BroadcastOwnedObjects(bool deltaFrame)
 		});
 }
 
+// To change to Pfab managed system in the future where all pfabs 
+// are loaded as disabled GameObjects that can be copied to new objects during runtime
 GameObject* NetworkedGame::GetPlayerPrefab(NetworkSpawnData* spawnPacket) 
 	{ return TutorialGame::AddPlayerToWorld(Vector3(90, 22, -50), spawnPacket);}
 
-void NetworkedGame::SpawnPlayerClient(int ownerId, int objectId, Prefab prefab)
+GameObject* NetworkedGame::GetItemPrefab(NetworkSpawnData* spawnPacket)
+	{ return TutorialGame::Loaditem(Vector3(93, 22, -53), spawnPacket);}
+
+GameObject* NetworkedGame::GetObjectFromPfab(size_t pfab, NetworkSpawnData data) {
+	GameObject* object;
+	if (pfab == Prefab::Player)
+		object = GetPlayerPrefab(&data);
+	else
+		object = GetItemPrefab(&data);
+	return object;
+}
+
+void NetworkedGame::SpawnObjectClient(int ownerId, int objectId, size_t pfab)
 {
-	// Will be prefab reference in the future	
 	bool clientOwned = ownerId == thisClient->GetPeerId();
 	NetworkSpawnData data = NetworkSpawnData();
 
 	data.clientOwned = clientOwned;
 	data.objId = objectId;
 	data.ownId = ownerId;
-	auto object = GetPlayerPrefab(&data);
+	data.pfab = pfab;
+	GameObject* object = GetObjectFromPfab(pfab, data);
 
 	if (clientOwned)
 		ownedObjects.emplace_back(object);
 }
 
-void NetworkedGame::SpawnPlayerServer(int ownerId, Prefab prefab)
+void NetworkedGame::SpawnObjectServer(int ownerId, size_t pfab)
 {
-	// Will be prefab reference in the future
 	bool serverOwned = ownerId == thisServer->GetPeerId();
 	NetworkSpawnData data = NetworkSpawnData();
 
 	data.clientOwned = serverOwned;
 	data.objId = nextObjectId;
 	data.ownId = ownerId;
-	auto object = GetPlayerPrefab(&data);
+	data.pfab = pfab;
+
+	GameObject* object = GetObjectFromPfab(pfab, data);
 
 	if (serverOwned)
 		ownedObjects.emplace_back(object);
@@ -220,6 +239,7 @@ void NetworkedGame::SpawnPlayerServer(int ownerId, Prefab prefab)
 	SpawnPacket* newPacket = new SpawnPacket();
 	newPacket->ownerId = ownerId;
 	newPacket->objectId = nextObjectId;
+	newPacket->pfabId = pfab;
 
 	SendToAllClients(newPacket);
 
@@ -227,7 +247,8 @@ void NetworkedGame::SpawnPlayerServer(int ownerId, Prefab prefab)
 	nextObjectId++;
 }
 
-bool HasNetworkComponent(GameObject* object, int& objectId, int& ownerId) {
+// Change to addNetworkObject component in the future so this info does not need to be included on every GameObject
+bool HasNetworkComponent(GameObject* object, int& objectId, int& ownerId, int& pFabId) {
 	if (!object)
 		return false;
 
@@ -239,6 +260,7 @@ bool HasNetworkComponent(GameObject* object, int& objectId, int& ownerId) {
 				std::cout << "NetworkComponent is not derived type" << std::endl;
 			objectId = networkComponent->GetObjectID();
 			ownerId = networkComponent->GetOwnerID();
+			pFabId = networkComponent->GetPfabID();
 			return true;
 		}
 	}
@@ -253,13 +275,16 @@ void NetworkedGame::SendSpawnPacketsOnClientConnect(int clientId)
 
 	int ownerId;
 	int objectId;
+	int pfabId;
+
 	for (auto i = first; i != last; ++i)
 	{
-		if (HasNetworkComponent(*i, objectId, ownerId))
+		if (HasNetworkComponent(*i, objectId, ownerId, pfabId))
 		{
 			SpawnPacket* newPacket = new SpawnPacket();
 			newPacket->ownerId = ownerId;
 			newPacket->objectId = objectId;
+			newPacket->pfabId = pfabId;
 			thisServer->SendPacketToPeer(newPacket, clientId);
 			delete newPacket;
 		}
@@ -304,7 +329,7 @@ void NetworkedGame::ReceiveSpawnPacket(int type, GamePacket* payload) {
 	if (type == Spawn_Object) {
 		if (thisClient) {
 			SpawnPacket* ackPacket = (SpawnPacket*)payload;
-			SpawnPlayerClient(ackPacket->ownerId, ackPacket->objectId, Prefab::Player);
+			SpawnObjectClient(ackPacket->ownerId, ackPacket->objectId, ackPacket->pfabId);
 		}
 	}
 }

--- a/CSC8508/NetworkedGame.h
+++ b/CSC8508/NetworkedGame.h
@@ -8,7 +8,7 @@ namespace NCL {
 		class GameServer;
 		class GameClient;
 		class NetworkPlayer;
-		enum Prefab { Player, EnemyA };
+		enum Prefab { Player, Enemy, Item };
 
 		class HostLobbyConnectEvent : public Event {};
 		class ClientLobbyConnectEvent : public Event 
@@ -17,8 +17,8 @@ namespace NCL {
 			ClientLobbyConnectEvent() : a(), b(), c(), d() {}
 		public:
 			char a;
-			char b; 
-			char c; 
+			char b;
+			char c;
 			char d;
 		};
 
@@ -38,8 +38,8 @@ namespace NCL {
 
 			void UpdateGame(float dt) override;
 
-			void SpawnPlayerClient(int ownerId, int objectId, Prefab prefab);
-			void SpawnPlayerServer(int ownerId, Prefab prefab);
+			void SpawnObjectClient(int ownerId, int objectId, size_t pfab);
+			void SpawnObjectServer(int ownerId, size_t prefab);
 
 			void StartLevel();
 			void ReceivePacket(int type, GamePacket* payload, int source) override;
@@ -65,7 +65,6 @@ namespace NCL {
 			void ReceiveFullDeltaStatePacket(int type, GamePacket* payload);
 			void ReceiveSpawnPacket(int type, GamePacket* payload);
 			bool SendToAllOtherClients(GamePacket* dataPacket, int ownerId);
-
 			GameServer* thisServer;
 			GameClient* thisClient;
 
@@ -73,9 +72,11 @@ namespace NCL {
 			int packetsToSnapshot;
 			int nextObjectId;
 
-			vector<GameObject*> ownedObjects;
-			GameObject* GetPlayerPrefab(NetworkSpawnData* spawnPacket = nullptr);
 			std::vector<int> playerStates;
+			vector<GameObject*> ownedObjects;
+			GameObject* GetObjectFromPfab(size_t pfab, NetworkSpawnData data);
+			GameObject* GetPlayerPrefab(NetworkSpawnData* spawnPacket = nullptr);
+			GameObject* GetItemPrefab(NetworkSpawnData* spawnPacket = nullptr);
 
 
 		};

--- a/CSC8508/TutorialGame.cpp
+++ b/CSC8508/TutorialGame.cpp
@@ -155,8 +155,6 @@ void TutorialGame::InitWorld()
 {
 	world->ClearAndErase();
 	physics->Clear();
-
-	Loaditem(Vector3(5, 0, 5));
 	std::string assetPath = GetAssetPath("myScene.pfab"); 
 	LoadWorld(assetPath);
 }

--- a/CSC8508/TutorialGame.cpp
+++ b/CSC8508/TutorialGame.cpp
@@ -42,6 +42,15 @@ GameObject* TutorialGame::LoadRoomPfab(std::string assetPath, Vector3 offset) {
 
 void LoadControllerMappings(Controller* controller)
 {
+#ifdef USE_PS5
+	controller->MapAxis(0, "Sidestep");
+	controller->MapAxis(2, "Forward");
+	controller->MapAxis(3, "XLook");
+	controller->MapAxis(4, "YLook");
+	controller->MapButton(KeyCodes::SHIFT, "Dash"); //Ps5 relevant buttons
+	controller->MapButton(KeyCodes::SPACE, "Jump"); // Keep names
+	controller->MapButton(KeyCodes::E, "Interact");
+#else
 	controller->MapAxis(0, "Sidestep");
 	controller->MapAxis(2, "Forward");
 	controller->MapAxis(3, "XLook");
@@ -49,6 +58,8 @@ void LoadControllerMappings(Controller* controller)
 	controller->MapButton(KeyCodes::SHIFT, "Dash");
 	controller->MapButton(KeyCodes::SPACE, "Jump");
 	controller->MapButton(KeyCodes::E, "Interact");
+#endif
+	controller->BindMappingsToHashIds();
 }
 
 void TutorialGame::InitialiseGame() {

--- a/CSC8508/TutorialGame.h
+++ b/CSC8508/TutorialGame.h
@@ -26,6 +26,7 @@ namespace NCL {
 		{
 			int objId;
 			int ownId;
+			size_t pfab;
 			bool clientOwned;
 		};
 
@@ -42,11 +43,11 @@ namespace NCL {
 
 			void LoadWorld(std::string assetPath);
 			void UpdateUI();
-			void Loaditem(const Vector3& position, NetworkSpawnData* spawnData = nullptr);
 			std::string GetAssetPath(std::string pfabName);
 
 			GameObject* LoadRoomPfab(std::string assetPath, Vector3 offset);
 			GameObject* AddPlayerToWorld(const Vector3& position, NetworkSpawnData* spawnData = nullptr);
+			GameObject* Loaditem(const Vector3& position, NetworkSpawnData* spawnData = nullptr);
 
 			MainMenu* GetMainMenu() { return mainMenu; }
 			ComponentAssemblyDefiner* componentAssembly;

--- a/CSC8508CoreClasses/INetworkComponent.cpp
+++ b/CSC8508CoreClasses/INetworkComponent.cpp
@@ -7,10 +7,11 @@ using namespace NCL::CSC8508;
 using namespace NCL;
 using namespace CSC8508;
 
-INetworkComponent::INetworkComponent(int objId, int ownId, int componentId, bool clientOwned)
+INetworkComponent::INetworkComponent(int objId, int ownId, int componentId, int pFabID, bool clientOwned)
 {
 	this->objectID = objId;
 	this->ownerID = ownId;
 	this->clientOwned = clientOwned;
+	this->pfabID = pFabID;
 	this->componentID = componentId;
 }

--- a/CSC8508CoreClasses/INetworkComponent.h
+++ b/CSC8508CoreClasses/INetworkComponent.h
@@ -39,7 +39,7 @@ namespace NCL::CSC8508
 	class INetworkComponent
 	{
 	public:
-		INetworkComponent(int objId, int ownId, int componentID, bool clientOwned);
+		INetworkComponent(int objId, int ownId, int componentID, int pfabId, bool clientOwned);
 
 		virtual ~INetworkComponent() = default;
 		virtual bool ReadEventPacket(INetworkPacket& p) { return false; }
@@ -47,6 +47,7 @@ namespace NCL::CSC8508
 		int GetObjectID() { return objectID; }
 		int GetComponentID() { return componentID; }
 		int GetOwnerID() { return ownerID; }
+		int GetPfabID() { return pfabID;  }
 		bool IsOwner() { return clientOwned; }
 
 	protected:
@@ -55,6 +56,7 @@ namespace NCL::CSC8508
 		int ownerID;
 		bool clientOwned;
 		int componentID;
+		int pfabID;
 
 		void SendEventPacket(INetworkPacket* packet)
 		{

--- a/CSC8508CoreClasses/INetworkDeltaComponent.cpp
+++ b/CSC8508CoreClasses/INetworkDeltaComponent.cpp
@@ -7,8 +7,8 @@ using namespace NCL::CSC8508;
 using namespace NCL;
 using namespace CSC8508;
 
-INetworkDeltaComponent::INetworkDeltaComponent(int objId, int ownId, int componentId, bool clientOwned, INetworkState* state)
-	: INetworkComponent(objId, ownId, componentId, clientOwned),
+INetworkDeltaComponent::INetworkDeltaComponent(int objId, int ownId, int componentId, int pfabID, bool clientOwned, INetworkState* state)
+	: INetworkComponent(objId, ownId, componentId, pfabID, clientOwned),
 	deltaErrors(0), fullErrors(0), lastFullState(state) {}
 
 vector<GamePacket*> INetworkDeltaComponent::WriteDeltaFullPacket(bool deltaFrame){

--- a/CSC8508CoreClasses/INetworkDeltaComponent.h
+++ b/CSC8508CoreClasses/INetworkDeltaComponent.h
@@ -43,7 +43,7 @@ namespace NCL::CSC8508
 	class INetworkDeltaComponent : public INetworkComponent
 	{
 	public:
-		INetworkDeltaComponent(int objId, int ownId, int componentId, bool clientOwned, INetworkState* state = nullptr);
+		INetworkDeltaComponent(int objId, int ownId, int componentId, int pfabID, bool clientOwned, INetworkState* state = nullptr);
 		virtual ~INetworkDeltaComponent() { delete lastFullState; }
 
 		vector<GamePacket*> WriteDeltaFullPacket(bool deltaFrame);

--- a/CSC8508CoreClasses/InputComponent.h
+++ b/CSC8508CoreClasses/InputComponent.h
@@ -59,8 +59,10 @@ namespace NCL::CSC8508
 
 		void CheckButtonBindings() {
 			for (auto binding : boundButtons) {
-				if (activeController->GetBoundButton(binding))
-					CallInputEvent(binding);
+				if (activeController->GetBoundButton(binding)) {
+					uint32_t hashBinding = activeController->GetButtonHashId(binding);
+					CallInputEvent(hashBinding);
+				}
 			}
 		}
 

--- a/CSC8508CoreClasses/InputNetworkComponent.h
+++ b/CSC8508CoreClasses/InputNetworkComponent.h
@@ -46,9 +46,9 @@ namespace NCL::CSC8508
 	class InputNetworkComponent :public InputComponent, public INetworkComponent
 	{
 	public:
-		InputNetworkComponent(GameObject& gameObject, Controller* controller, int objId, int ownId, int componId, bool clientOwned) :
+		InputNetworkComponent(GameObject& gameObject, Controller* controller, int objId, int ownId, int componId, int pfabID, bool clientOwned) :
 			InputComponent(gameObject, controller), 
-			INetworkComponent(objId, ownId, componId, clientOwned), reset(true) {}
+			INetworkComponent(objId, ownId, componId, pfabID, clientOwned), reset(true) {}
 
 		~InputNetworkComponent() = default;
 

--- a/CSC8508CoreClasses/TransformNetworkComponent.h
+++ b/CSC8508CoreClasses/TransformNetworkComponent.h
@@ -42,8 +42,8 @@ namespace NCL::CSC8508
 	class TransformNetworkComponent :public IComponent, public INetworkDeltaComponent
 	{
 	public:
-		TransformNetworkComponent(GameObject& gameObject, int objId, int ownId, int componId, bool clientOwned): 
-			INetworkDeltaComponent(objId, ownId, componId, clientOwned, new TransformNetworkState), 
+		TransformNetworkComponent(GameObject& gameObject, int objId, int ownId, int componId, int pfabID, bool clientOwned): 
+			INetworkDeltaComponent(objId, ownId, componId, pfabID, clientOwned, new TransformNetworkState),
 			IComponent(gameObject),
 			myObject(gameObject) {}
 		

--- a/NCLCoreClasses/CMakeLists.txt
+++ b/NCLCoreClasses/CMakeLists.txt
@@ -126,6 +126,7 @@ target_precompile_headers(${PROJECT_NAME} PRIVATE
     <algorithm>
     <assert.h>  
 )
+include_directories("../SerializedSave/")
 
 ################################################################################
 # Compile and link options

--- a/NCLCoreClasses/Controller.cpp
+++ b/NCLCoreClasses/Controller.cpp
@@ -7,6 +7,7 @@ Comments and queries to: richard-gordon.davison AT ncl.ac.uk
 https://research.ncl.ac.uk/game/
 */
 #include "Controller.h"
+#include "SaveManager.h"
 
 void Controller::MapAxis(uint32_t axis, const std::string& name)  {
 	axisMappings.insert({name, axis});
@@ -50,4 +51,111 @@ uint32_t Controller::GetNamedAxisBinding(const std::string& axis) const {
 		return a->second;
 	}
 	return -1;
+}
+
+vector<uint32_t> Controller::GetBoundButtons() const {
+	vector<uint32_t> boundButtons;
+	for (auto binding : buttonMappings)
+		boundButtons.push_back(binding.second);
+	return boundButtons;
+}
+
+vector<uint32_t> Controller::GetBoundAnalogue() const {
+	vector<uint32_t> boundAnalogue;
+	for (auto binding : analogueMappings)
+		boundAnalogue.push_back(binding.second);
+	return boundAnalogue;
+}
+
+vector<uint32_t> Controller::GetBoundAxis() const {
+	vector<uint32_t> boundAxis;
+	for (auto binding : axisMappings)
+		boundAxis.push_back(binding.second);
+	return boundAxis;
+}
+
+uint32_t Controller::GetHashId(std::string str) {
+	return NCL::CSC8508::SaveManager::MurmurHash3_64(str.c_str(), str.size());
+}
+
+uint32_t Controller::GetAxisFromHashId(const uint32_t key) const {
+	auto a = axisHashMaps.find(key);
+	if (a != axisHashMaps.end())
+		return a->second;
+	return 0.0f;
+}
+
+uint32_t Controller::GetButtonFromHashId(const uint32_t key) const {
+	auto a = buttonHashMaps.find(key);
+	if (a != buttonHashMaps.end())
+		return a->second;
+	return 0.0f;
+}
+
+uint32_t Controller::GetAnalogueFromHashId(const uint32_t key) const {
+	auto a = analogueHashMaps.find(key);
+	if (a != analogueHashMaps.end())
+		return a->second;
+	return 0.0f;
+}
+
+uint32_t Controller::GetAxisHashId(const std::string& name) const {
+	auto a = axisMappings.find(name);
+	if (a != axisMappings.end())
+		return GetAxisHashId(a->second);
+	return 0.0f;
+}
+
+uint32_t Controller::GetButtonHashId(const std::string name) const {
+	auto a = buttonMappings.find(name);
+	if (a != buttonMappings.end())
+		return GetButtonHashId(a->second);
+	return 0.0f;
+}
+
+uint32_t Controller::GetAnalogueHashId(const std::string name) const {
+	auto a = axisMappings.find(name);
+	if (a != axisMappings.end())
+		return GetAxisHashId(a->second);
+	return 0.0f;
+}
+
+uint32_t Controller::GetAxisHashId(const uint32_t key) const {
+	uint32_t foundKey = 0;
+	for (const auto& pair : axisHashMaps) {
+		if (pair.second == key) {
+			foundKey = pair.first;
+			break;
+		}
+	}
+	return foundKey;
+}
+uint32_t Controller::GetButtonHashId(const uint32_t key) const {
+	uint32_t foundKey = 0;
+	for (const auto& pair : buttonHashMaps) {
+		if (pair.second == key) {
+			foundKey = pair.first;
+			break;
+		}
+	}
+	return foundKey;
+}
+uint32_t Controller::GetAnalogueHashId(const uint32_t key) const {
+	uint32_t foundKey = 0;
+	for (const auto& pair : analogueHashMaps) {
+		if (pair.second == key) {
+			foundKey = pair.first;
+			break;
+		}
+	}
+	return foundKey;
+}
+
+void Controller::BindMappingsToHashIds() {
+	for (std::pair<std::string, uint32_t> binding : analogueMappings)
+		analogueHashMaps[GetHashId(binding.first)] = binding.second;
+	for (std::pair<std::string, uint32_t> binding : buttonMappings)
+		buttonHashMaps[GetHashId(binding.first)] = binding.second;
+	for (std::pair<std::string, uint32_t> binding : axisMappings)
+		axisHashMaps[GetHashId(binding.first)] = binding.second;
 }

--- a/NCLCoreClasses/Controller.h
+++ b/NCLCoreClasses/Controller.h
@@ -30,34 +30,34 @@ public:
 
 	virtual void Update(float dt = 0.0f) {}
 	uint32_t GetNamedAxisBinding(const std::string& name) const;
-
-	vector<uint32_t> GetBoundButtons() const {
-		vector<uint32_t> boundButtons;
-		for (auto binding : buttonMappings) {
-			boundButtons.push_back(binding.second);
-		}
-		return boundButtons;
-	}
-
 	virtual bool GetBoundButton(uint32_t keyId) const { return false; }
 
-	vector<uint32_t> GetBoundAnalogue() const {
-		vector<uint32_t> boundAnalogue;
-		for (auto binding : analogueMappings) {
-			boundAnalogue.push_back(binding.second);
-		}
-		return boundAnalogue;
-	}
+	vector<uint32_t> GetBoundButtons() const;
+	vector<uint32_t> GetBoundAnalogue() const;
+	vector<uint32_t> GetBoundAxis() const;
 
-	vector<uint32_t> GetBoundAxis() const {
-		vector<uint32_t> boundAxis;
-		for (auto binding : axisMappings) {
-			boundAxis.push_back(binding.second);
-		}
-		return boundAxis;
-	}
+	uint32_t GetHashId(std::string str);
+
+	uint32_t GetAxisFromHashId(const uint32_t key) const;
+	uint32_t GetButtonFromHashId(const uint32_t key) const;
+	uint32_t GetAnalogueFromHashId(const uint32_t key) const;
+
+	uint32_t GetAxisHashId(const std::string& name) const;
+	uint32_t GetButtonHashId(const std::string name) const;
+	uint32_t GetAnalogueHashId(const std::string name) const;
+
+	uint32_t GetAxisHashId(const uint32_t key) const;
+	uint32_t GetButtonHashId(const uint32_t key) const;
+	uint32_t GetAnalogueHashId(const uint32_t key) const;
+
+	void BindMappingsToHashIds();
+
 protected:
 	std::map<std::string, uint32_t> buttonMappings;
 	std::map<std::string, uint32_t> analogueMappings;
 	std::map<std::string, uint32_t> axisMappings;
+
+	std::map<uint32_t, uint32_t> buttonHashMaps;
+	std::map<uint32_t, uint32_t> analogueHashMaps;
+	std::map<uint32_t, uint32_t> axisHashMaps;
 };

--- a/Tools/imgui.ini
+++ b/Tools/imgui.ini
@@ -3,18 +3,30 @@ Pos=60,60
 Size=400,400
 
 [Window][Framerate]
-Pos=50,50
-Size=120,50
+Pos=47,28
+Size=75,44
 
 [Window][Main Menu]
 Pos=80,480
 Size=600,500
 
 [Window][Audio Sliders]
-Pos=800,300
-Size=500,125
+Pos=566,168
+Size=283,168
 
 [Window][Health]
 Pos=100,1000
 Size=400,100
+
+[Window][Inventory]
+Pos=283,56
+Size=188,112
+
+[Window][MainMenu]
+Pos=94,280
+Size=944,561
+
+[Window][Healthbar]
+Pos=94,504
+Size=377,224
 


### PR DESCRIPTION
Inventories are now synced between clients
* `InventoryNetworkComponent` rolls back Inventory state on Full Packet differences
* Controller bindings send hashmap ids to button binding instead of the binding itself to allow for different key bindings between clients 
* Spawn networked item methods in NetworkedGame